### PR TITLE
fix: adapt project to python3

### DIFF
--- a/easygui/boxes/choice_box.py
+++ b/easygui/boxes/choice_box.py
@@ -73,8 +73,8 @@ def make_list_or_none(obj, cast_type=None):
         if cast_type is not None:
             try:
                 ret_val = cast_type(obj)
-            except Exception, e:
-                raise Exception("Value {} cannot be converted to type: {}".format(obj, cast_type))
+            except Exception as e:
+                raise Exception("Value {} cannot be converted to type: {}".format(obj, cast_type)) from e
         ret_val = [ret_val,]
     # Convert all elements to cast_type
     if cast_type is not None:

--- a/mc2tex.py
+++ b/mc2tex.py
@@ -657,7 +657,7 @@ def convert(inpath, outpath):
 	outfile.write(tex_intro)
 
 	for l in outlines:
-		outfile.write(l.encode("utf8"))
+		outfile.write(l)
 	
 	outfile.write(tex_outro)
 


### PR DESCRIPTION
This PR migrates the project to be compatible with Python 3.x. 
This project appears useful, so I have updated it to run on modern Python versions.

Thanks for this project! It saved me a lot of time reading old MathCAD 14 files without having MathCAD installed!